### PR TITLE
Feature: Make overlay closing and Recents mappable via chords

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -48,6 +48,7 @@ from .operators import (
     CHORDSONG_OT_ImportOverlayTheme,
     CHORDSONG_OT_Leader,
     CHORDSONG_OT_ResetState,
+    CHORDSONG_OT_CloseOverlay,
     CHORDSONG_OT_Load_Autosave,
     CHORDSONG_OT_Load_Config,
     CHORDSONG_OT_Load_Default,
@@ -119,6 +120,7 @@ _classes = (
     CHORDSONG_OT_ImportOverlayTheme,
     CHORDSONG_OT_Leader,
     CHORDSONG_OT_ResetState,
+    CHORDSONG_OT_CloseOverlay,
     CHORDSONG_OT_Load_Autosave,
     CHORDSONG_OT_Load_Config,
     CHORDSONG_OT_Load_Default,
@@ -177,7 +179,7 @@ def register():
     """Register addon classes and keymaps."""
     for cls in _classes:
         _safe_register_class(cls)
-    
+
     # Clear operator cache on addon enable to ensure fresh operator list
     try:
         from .ui.prefs import clear_operator_cache
@@ -213,6 +215,7 @@ def register():
                 # Create default SPACE key binding
                 # User customizations in keyconfigs.user take precedence automatically
                 kmi = km.keymap_items.new(CHORDSONG_OT_Leader.bl_idname, 'SPACE', 'PRESS')
+                kmi.repeat = False  # Disable key repeat by default
 
             addon_keymaps.append((km, kmi))
 
@@ -295,7 +298,7 @@ def register():
             elif not user_config_path and not has_existing_mappings:
                 if hasattr(prefs, "ensure_defaults"):
                     prefs.ensure_defaults()
-            
+
             # Normalize order indices (for existing blend files with old data)
             # This ensures no gaps in the sequence even if loading old configs
             from .core.config_io import _normalize_order_indices
@@ -342,7 +345,7 @@ def unregister():
                 pass
 
     addon_keymaps.clear()
-    
+
     # Clear operator cache on addon disable
     try:
         from .ui.prefs import clear_operator_cache

--- a/core/engine.py
+++ b/core/engine.py
@@ -262,11 +262,11 @@ def candidates_for_prefix(mappings, buffer_tokens, context=None):
         if not getattr(m, "enabled", True):
             continue
 
-        # Skip chordsong.recents operator
+        # Skip chordsong.recents and chordsong.close_overlay operators
         mapping_type = get_str_attr(m, "mapping_type", "OPERATOR")
         if mapping_type == "OPERATOR":
             operator = get_str_attr(m, "operator")
-            if operator == "chordsong.recents":
+            if operator in ("chordsong.recents", "chordsong.close_overlay"):
                 continue
 
         tokens = split_chord(get_str_attr(m, "chord"))

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -13,7 +13,7 @@ from .group.group_remove import CHORDSONG_OT_Group_Remove
 from .group.group_rename import CHORDSONG_OT_Group_Rename
 from .group.group_select import CHORDSONG_OT_Group_Select
 from .icon_select import CHORDSONG_OT_Icon_Select, CHORDSONG_OT_Icon_Select_Apply
-from .leader import CHORDSONG_OT_Leader, CHORDSONG_OT_ResetState, cleanup_all_handlers
+from .leader import CHORDSONG_OT_Leader, CHORDSONG_OT_ResetState, CHORDSONG_OT_CloseOverlay, cleanup_all_handlers
 from .config.append_config import CHORDSONG_OT_Append_Config
 from .config.clear_search import CHORDSONG_OT_Clear_Search
 from .config.clear_operator_cache import CHORDSONG_OT_Clear_Operator_Cache
@@ -83,6 +83,7 @@ __all__ = [
     "CHORDSONG_OT_Icon_Select_Apply",
     "CHORDSONG_OT_Leader",
     "CHORDSONG_OT_ResetState",
+    "CHORDSONG_OT_CloseOverlay",
     "CHORDSONG_OT_Load_Autosave",
     "CHORDSONG_OT_Load_Config",
     "CHORDSONG_OT_Load_Default",

--- a/operators/leader.py
+++ b/operators/leader.py
@@ -15,6 +15,10 @@ from ..core.engine import (
     parse_kwargs,
     filter_mappings_by_context,
     get_leader_key_type,
+    get_leader_key_token,
+    split_chord,
+    tokens_match,
+    get_str_attr,
 )
 from ..core.history import add_to_history
 from ..ui.overlay import draw_overlay, draw_fading_overlay
@@ -37,6 +41,32 @@ _fading_overlay_state = {
 
 # Global state for panel visibility (shared between Leader and Recents)
 _panel_states_global = {}
+
+# ============================================================
+# MIGRATION CODE: double-leader Recents notification
+# ============================================================
+# TO REMOVE LATER ON: just delete all "MIGRATION CODE" blocks in this file as
+# well as in ui/prefs.py.
+#
+# N.B. Also delete the _recents_notice_dismissed property in prefs.py, and the
+# _show_recents_migration_notice function in leader.py (below).
+# ============================================================
+def _show_recents_migration_notice(context, p, leader_token):
+    """Show one-time notification about Recents moving to chord mappings."""
+    def draw_notice(self, context):
+        layout = self.layout
+        layout.label(text="Recents has been moved to a chord mapping", icon='INFO')
+        layout.separator()
+        layout.label(text="The double-tap Recents feature has been replaced.")
+        layout.label(text=f"To restore it, add a chord like '{leader_token}' → chordsong.recents.")
+        layout.label(text="You can also bind it to any other key (e.g., 'r').")
+        layout.separator()
+        layout.prop(p, "recents_notice_dismissed", text="Don't show again")
+
+    context.window_manager.popup_menu(draw_notice, title="Chord Song Update", icon='INFO')
+# ============================================================
+# END MIGRATION CODE
+# ============================================================
 
 def _show_fading_overlay(_context, chord_tokens, label, icon, show_chord=True):
     """Start showing a fading overlay for the executed chord.
@@ -379,6 +409,18 @@ class CHORDSONG_OT_ResetState(bpy.types.Operator):
         return {"FINISHED"}
 
 
+class CHORDSONG_OT_CloseOverlay(bpy.types.Operator):
+    """Close the Chord Song overlay if it's open"""
+
+    bl_idname = "chordsong.close_overlay"
+    bl_label = "Close Overlay"
+    bl_options = {"REGISTER"}
+
+    def execute(self, context: bpy.types.Context):
+        # Simply call reset_state which already does the cleanup
+        return bpy.ops.chordsong.reset_state('EXEC_DEFAULT')
+
+
 class CHORDSONG_OT_Leader(bpy.types.Operator):
     """Start chord capture (leader)"""
 
@@ -520,7 +562,7 @@ class CHORDSONG_OT_Leader(bpy.types.Operator):
                     self.area = area
                 def __getattr__(self, name):
                     return getattr(self._ctx, name)
-            
+
             context = ContextWithRegion(bpy.context, self._region, self._area)
 
         # Filter mappings by context for overlay display
@@ -543,7 +585,7 @@ class CHORDSONG_OT_Leader(bpy.types.Operator):
         self._ctrl_held = False
         self._alt_held = False
         self._shift_held = False
-        
+
         # Store the leader key to ignore its first RELEASE if it's a mouse button
         # This prevents double-triggering when mouse buttons are used as leader key
         self._leader_key_type = get_leader_key_type()
@@ -753,6 +795,10 @@ class CHORDSONG_OT_Leader(bpy.types.Operator):
             return {"CANCELLED"}
 
     def _modal_inner(self, context: bpy.types.Context, event: bpy.types.Event):
+        # Ignore leader key repeat events
+        if event.type == get_leader_key_type() and event.value == 'PRESS' and event.is_repeat:
+            return {"RUNNING_MODAL"}
+
         global _panel_states_global
         p = prefs(context)
 
@@ -760,7 +806,6 @@ class CHORDSONG_OT_Leader(bpy.types.Operator):
         if event.type == "ESC" and event.value == "PRESS":
             self._finish(context)
             return {"CANCELLED"}
-
 
         # Backspace to go up one level
         if event.type == "BACK_SPACE" and event.value == "PRESS":
@@ -773,6 +818,77 @@ class CHORDSONG_OT_Leader(bpy.types.Operator):
                 # No buffer, treat as cancel
                 self._finish(context)
                 return {"CANCELLED"}
+
+        # ============================================================
+        # MIGRATION CODE: double-leader Recents notification
+        # ============================================================
+        # TO REMOVE LATER ON: just delete all "MIGRATION CODE" blocks in this file as
+        # well as in ui/prefs.py.
+        #
+        # N.B. Also delete the recents_notice_dismissed property in prefs.py, and the
+        # _show_recents_migration_notice function in leader.py.
+        # ============================================================
+        leader_key = get_leader_key_type()
+        if not self._buffer and event.type == leader_key:
+            # Check if user has any single-token Recents chord
+            has_any_recents_chord = False
+            for m in p.mappings:
+                if getattr(m, "mapping_type", "OPERATOR") == "OPERATOR":
+                    if get_str_attr(m, "operator") == "chordsong.recents" and getattr(m, "enabled", True):
+                        chord = get_str_attr(m, "chord")
+                        if chord and " " not in chord:
+                            has_any_recents_chord = True
+                            break
+
+            # If user already has a Recents chord, auto-dismiss the notice
+            if has_any_recents_chord:
+                if not getattr(p, "recents_notice_dismissed", False):
+                    p.recents_notice_dismissed = True
+            else:
+                # Existing users = have any mappings at all (not fresh install)
+                is_existing_user = len(p.mappings) > 0
+
+                if is_existing_user and not getattr(p, "recents_notice_dismissed", False):
+                    leader_token = get_leader_key_token()
+                    _show_recents_migration_notice(context, p, leader_token)
+                    return {"RUNNING_MODAL"}
+        # ============================================================
+        # END MIGRATION CODE
+        # ============================================================
+
+        # Check for close chord (intelligent: only close if pressing the key wouldn't form a valid chord prefix)
+        pressed_key = normalize_token(event.type, shift=event.shift, ctrl=event.ctrl, alt=event.alt, oskey=event.oskey)
+
+        # Find all single-token close chords
+        close_chords = []
+        for m in p.mappings:
+            if getattr(m, "mapping_type", "OPERATOR") == "OPERATOR":
+                if get_str_attr(m, "operator") == "chordsong.close_overlay" and getattr(m, "enabled", True):
+                    chord = get_str_attr(m, "chord")
+                    if chord and " " not in chord:
+                        close_chords.append(chord)
+
+        # If pressed key is a close chord
+        if pressed_key in close_chords:
+            # Check if adding this key would create a valid prefix for any chord
+            test_buffer = self._buffer + [pressed_key]
+
+            # Check if any enabled mapping starts with this test_buffer as a prefix
+            is_prefix = False
+            for m in p.mappings:
+                if not getattr(m, "enabled", True):
+                    continue
+                chord_tokens = split_chord(get_str_attr(m, "chord"))
+                if len(chord_tokens) >= len(test_buffer):
+                    if all(tokens_match(m_tok, b_tok) for m_tok, b_tok in zip(chord_tokens[:len(test_buffer)], test_buffer)):
+                        is_prefix = True
+                        break
+
+            # If not a prefix of any chord, close immediately
+            if not is_prefix:
+                self._finish(context)
+                return {"CANCELLED"}
+            # Otherwise, let it be processed as a normal token below
 
         # Handle modifier key events BEFORE checking event.value to catch RELEASE events
         # Track CTRL
@@ -811,10 +927,10 @@ class CHORDSONG_OT_Leader(bpy.types.Operator):
         # Mouse buttons should trigger on RELEASE to avoid conflicts with Blender's default actions
         # (e.g., M3 triggering rotate view on PRESS, getting stuck if we consume the event)
         is_mouse_button = event.type in {
-            "LEFTMOUSE", "RIGHTMOUSE", "MIDDLEMOUSE", 
+            "LEFTMOUSE", "RIGHTMOUSE", "MIDDLEMOUSE",
             "BUTTON4MOUSE", "BUTTON5MOUSE", "BUTTON6MOUSE", "BUTTON7MOUSE"
         }
-        
+
         # For mouse buttons, wait for RELEASE; for everything else (including wheel), wait for PRESS
         if is_mouse_button:
             if event.value != "RELEASE":
@@ -850,40 +966,6 @@ class CHORDSONG_OT_Leader(bpy.types.Operator):
 
         # Reset last modifier type after a non-modifier key is processed
         self._last_mod_type = None
-
-        # Check for <leader><leader>
-        # If buffer is empty and user presses the leader key again, show recents
-        leader_key = get_leader_key_type()
-        
-        # Ignore the first RELEASE of a mouse button leader key to prevent double-trigger
-        if hasattr(self, '_ignore_leader_release') and self._ignore_leader_release:
-            if event.type == self._leader_key_type and event.value == "RELEASE":
-                self._ignore_leader_release = False
-                return {"RUNNING_MODAL"}
-        
-        if not self._buffer and event.type == leader_key:
-            # Open recents instead of repeat
-            # Don't restore panels here - Recents will handle them
-            p = prefs(context)
-            global _panel_states_global
-            if self._panel_states:
-                # Transfer panel state to Recents by storing it globally
-                # Recents will restore panels when it finishes
-                _panel_states_global = self._panel_states.copy()
-                # Clear our state so _finish doesn't restore
-                self._panel_states = {}
-            # Finish without restoring panels (they'll be handled by Recents)
-            self._finish(context, restore_panels=False)
-            try:
-                bpy.ops.chordsong.recents('INVOKE_DEFAULT')
-            except Exception as e:
-                print(f"Chord Song: Failed to open recents: {e}")
-                # If Recents failed, restore panels now
-                if _panel_states_global:
-                    self._panel_states = _panel_states_global.copy()
-                    self._restore_panels(context)
-                    _panel_states_global = {}
-            return {"FINISHED"}
 
         # Normal mode - accumulate tokens in buffer
         self._buffer.append(tok)
@@ -1485,7 +1567,8 @@ class CHORDSONG_OT_Leader(bpy.types.Operator):
                     if success:
                         # Skip fading overlay and history for scripts_overlay operator
                         primary_operator = operators_to_run[0]["op"] if operators_to_run else None
-                        if primary_operator != "chordsong.scripts_overlay":
+                        skip_operators = ("chordsong.scripts_overlay", "chordsong.recents", "chordsong.close_overlay")
+                        if primary_operator not in skip_operators:
                             overlay_ctx = validate_viewport_context(ctx_viewport) if ctx_viewport else None
                             if overlay_ctx and overlay_ctx.get("area") and overlay_ctx.get("region"):
                                 try:

--- a/operators/recents.py
+++ b/operators/recents.py
@@ -11,6 +11,7 @@ from ..core.engine import (
     normalize_token,
     get_leader_key_type,
     get_leader_key_token,
+    get_str_attr,
 )
 from ..utils.render import (
     DrawHandlerManager,
@@ -45,6 +46,7 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
 
     _buffer = None  # Buffer for capturing digits
     _draw_manager = None  # DrawHandlerManager instance
+    _should_close = False  # Flag to indicate modal should close
 
     def _draw_callback(self):
         """Draw callback for the recents overlay."""
@@ -79,7 +81,7 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
                     self.area = area
                 def __getattr__(self, name):
                     return getattr(self._ctx, name)
-            
+
             context = ContextWithRegion(bpy.context, self._draw_manager.region, self._draw_manager.area)
 
         # Draw the recents overlay
@@ -209,8 +211,8 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
                 iw, _ = blf.dimensions(0, entry.icon)
                 max_icon_w = max(max_icon_w, iw)
 
-            # Chord width
-            chord_text = "+".join(entry.chord_tokens)
+            # Chord width (display with spaces, not plus signs)
+            chord_text = " ".join(entry.chord_tokens)
             cw, _ = blf.dimensions(0, chord_text)
             max_chord_w = max(max_chord_w, cw)
 
@@ -242,11 +244,39 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
         footer_bg_top = footer_y + chord_size # Default if no footer
 
         if p.overlay_show_footer:
-            leader_token = get_leader_key_token()
-            footer_items = [
-                {"token": "ESC", "label": "Close", "icon": ""},
-                {"token": leader_token, "label": "Repeat Most Recent", "icon": ""}
-            ]
+            # Find single-token Recents chords only (no spaces)
+            recents_chords = []
+            for m in p.mappings:
+                if getattr(m, "mapping_type", "OPERATOR") == "OPERATOR":
+                    if get_str_attr(m, "operator") == "chordsong.recents" and getattr(m, "enabled", True):
+                        chord = get_str_attr(m, "chord")
+                        # Only include single-token chords (no spaces)
+                        if chord and " " not in chord:
+                            recents_chords.append(chord)
+
+            # Find single-token Close Overlay chords (no spaces)
+            close_chords = []
+            for m in p.mappings:
+                if getattr(m, "mapping_type", "OPERATOR") == "OPERATOR":
+                    if get_str_attr(m, "operator") == "chordsong.close_overlay" and getattr(m, "enabled", True):
+                        chord = get_str_attr(m, "chord")
+                        # Only include single-token chords (no spaces)
+                        if chord and " " not in chord:
+                            close_chords.append(chord)
+
+            # Build footer items
+            if close_chords:
+                display_chord = close_chords[0].replace(" ", "+")
+                footer_items = [{"token": f"ESC|{display_chord}", "label": "Close", "icon": ""}]
+            else:
+                footer_items = [{"token": "ESC", "label": "Close", "icon": ""}]
+
+            if recents_chords:
+                display_chord = recents_chords[0].replace(" ", "+")
+                footer_items.append({"token": display_chord, "label": "Repeat Most Recent", "icon": ""})
+            else:
+                leader_token = get_leader_key_token()
+                footer_items.append({"token": leader_token, "label": "Repeat Most Recent", "icon": ""})
 
             # Use prefs for footer text size
             footer_text_size_base = getattr(p, "overlay_font_size_footer", 12)
@@ -309,7 +339,7 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
 
             # For scripts (PYTHON_FILE), draw icon in icon column and skip chord
             is_script = entry.mapping_type == "PYTHON_FILE"
-            
+
             if is_script:
                 # Draw Python icon in icon column (aligned with other icons)
                 if entry.icon:
@@ -329,13 +359,13 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
                     except Exception:
                         pass
 
-                # Draw chord (50% alpha)
-                chord_text = "+".join(entry.chord_tokens)
+                # Draw chord (50% alpha) - using spaces
+                chord_text = " ".join(entry.chord_tokens)
                 blf.size(0, chord_size)
                 blf.color(0, col_chord[0], col_chord[1], col_chord[2], col_chord[3] * 0.25)
                 blf.position(0, chord_col_x, current_y, 0)
                 blf.draw(0, chord_text)
-                
+
                 label_start_x = label_col_x
 
             # Draw label
@@ -361,6 +391,7 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
             _panel_states_global.clear()
 
         self._buffer = []
+        self._should_close = False
         self._draw_manager = DrawHandlerManager()
         self._draw_manager.ensure_handler(context, self._draw_callback, p)
 
@@ -381,7 +412,7 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
         """Restore T and N panels to their original visibility state."""
         if not hasattr(self, '_panel_states') or not self._panel_states:
             return
-        
+
         # Iterate through all areas in all windows
         for window in context.window_manager.windows:
             try:
@@ -393,24 +424,24 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
                         area_ptr = area.as_pointer()
                         if area_ptr not in self._panel_states:
                             continue
-                        
+
                         panel_state = self._panel_states[area_ptr]
                         space_type = panel_state.get('space_type', 'VIEW_3D')
-                        
+
                         # Only restore panels in areas matching the stored space type
                         if area.type != space_type:
                             continue
-                        
+
                         # Get the space data
                         space = None
                         for s in area.spaces:
                             if s.type == space_type:
                                 space = s
                                 break
-                        
+
                         if not space:
                             continue
-                        
+
                         # Restore Asset Shelf
                         if 'asset_shelf' in panel_state and hasattr(space, 'show_region_asset_shelf'):
                             if space.show_region_asset_shelf != panel_state['asset_shelf']:
@@ -429,7 +460,7 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
                         continue
             except Exception:
                 continue
-        
+
         # Clear stored states
         self._panel_states = {}
 
@@ -438,7 +469,7 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
         self._finish(context)
 
     def _execute_history_entry(self, context, entry):
-        """Execute a history entry."""
+        """Execute a history entry. Returns True if modal should close."""
         from ..operators.leader import _show_fading_overlay
 
         # Capture viewport context BEFORE finishing modal (when we have valid context)
@@ -446,7 +477,7 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
 
         # Execute based on mapping type
         if entry.mapping_type == "OPERATOR":
-            # Execute operator DIRECTLY in modal context (preserves F9)
+            # Execute operator
             from ..utils.render import validate_viewport_context
             valid_ctx = validate_viewport_context(ctx_viewport) if ctx_viewport else None
             ctx_wrapper = _create_context_wrapper(valid_ctx)
@@ -455,11 +486,10 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
                 _show_fading_overlay(bpy.context, entry.chord_tokens, entry.label, entry.icon)
             elif error_msg:
                 _show_fading_overlay(bpy.context, entry.chord_tokens, error_msg, "CANCEL")
-            # Finish modal AFTER execution
-            self._finish(context)
-            return
+            # Signal that modal should close
+            return True
 
-        # For non-operator types, finish modal first, then use timer
+        # For non-operator types, close modal first, then use timer
         self._finish(context)
 
         if entry.mapping_type == "PYTHON_FILE":
@@ -505,6 +535,8 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
 
             bpy.app.timers.register(execute_property_delayed, first_interval=0.01)
 
+        return True  # Close modal after non-operator types as well
+
     def modal(self, context: bpy.types.Context, event: bpy.types.Event):
         try:
             return self._modal_inner(context, event)
@@ -519,6 +551,15 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
             return {"CANCELLED"}
 
     def _modal_inner(self, context: bpy.types.Context, event: bpy.types.Event):
+        # Ignore leader key repeat events
+        if event.type == get_leader_key_type() and event.value == 'PRESS' and event.is_repeat:
+            return {"RUNNING_MODAL"}
+
+        # If modal should close, do it now
+        if self._should_close:
+            self._finish(context)
+            return {"FINISHED"}
+
         history = get_history()
 
         # Cancel keys
@@ -529,13 +570,42 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
         if event.value != "PRESS":
             return {"RUNNING_MODAL"}
 
-        # Check for leader key to repeat most recent
-        leader_key = get_leader_key_type()
-        if event.type == leader_key:
+        # Check for single-token Close Overlay chord to close the overlay
+        p = prefs(context)
+        pressed_key = normalize_token(event.type, shift=event.shift, ctrl=event.ctrl, alt=event.alt, oskey=event.oskey)
+
+        # Find all single-token Close Overlay chords (no spaces)
+        single_token_close = []
+        for m in p.mappings:
+            if getattr(m, "mapping_type", "OPERATOR") == "OPERATOR":
+                if get_str_attr(m, "operator") == "chordsong.close_overlay" and getattr(m, "enabled", True):
+                    chord = get_str_attr(m, "chord")
+                    if chord and " " not in chord:
+                        single_token_close.append(chord)
+
+        if pressed_key in single_token_close:
+            self._finish(context)
+            return {"CANCELLED"}
+
+        # Check for single-token Recents chord to repeat most recent
+        # Find all single-token Recents chords (no spaces)
+        single_token_recents = []
+        for m in p.mappings:
+            if getattr(m, "mapping_type", "OPERATOR") == "OPERATOR":
+                if get_str_attr(m, "operator") == "chordsong.recents" and getattr(m, "enabled", True):
+                    chord = get_str_attr(m, "chord")
+                    if chord and " " not in chord:
+                        single_token_recents.append(chord)
+
+        if pressed_key in single_token_recents:
             entry = history.get(0)
             if entry:
-                self._execute_history_entry(context, entry)
-                return {"FINISHED"}
+                should_close = self._execute_history_entry(context, entry)
+                if should_close:
+                    self._should_close = True
+                    return {"RUNNING_MODAL"}  # Will close on next event cycle
+                else:
+                    return {"FINISHED"}
             else:
                 self.report({"WARNING"}, "No history entry to repeat")
                 self._finish(context)
@@ -549,8 +619,12 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
                 if 1 <= number <= 9:
                     entry = history.get(number - 1)  # Convert to 0-based index
                     if entry:
-                        self._execute_history_entry(context, entry)
-                        return {"FINISHED"}
+                        should_close = self._execute_history_entry(context, entry)
+                        if should_close:
+                            self._should_close = True
+                            return {"RUNNING_MODAL"}
+                        else:
+                            return {"FINISHED"}
                     else:
                         self.report({"WARNING"}, f"No history entry #{number}")
                         self._finish(context)
@@ -564,8 +638,12 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
             index = ord(tok) - ord('a') + 9
             entry = history.get(index)
             if entry:
-                self._execute_history_entry(context, entry)
-                return {"FINISHED"}
+                should_close = self._execute_history_entry(context, entry)
+                if should_close:
+                    self._should_close = True
+                    return {"RUNNING_MODAL"}
+                else:
+                    return {"FINISHED"}
             else:
                 self.report({"WARNING"}, f"No history entry at position '{tok}'")
                 self._finish(context)
@@ -577,8 +655,12 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
             index = ord(tok[1]) - ord('a') + 35
             entry = history.get(index)
             if entry:
-                self._execute_history_entry(context, entry)
-                return {"FINISHED"}
+                should_close = self._execute_history_entry(context, entry)
+                if should_close:
+                    self._should_close = True
+                    return {"RUNNING_MODAL"}
+                else:
+                    return {"FINISHED"}
             else:
                 self.report({"WARNING"}, f"No history entry at position '{tok}'")
                 self._finish(context)
@@ -590,8 +672,12 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
             index = shifted_map[tok]
             entry = history.get(index)
             if entry:
-                self._execute_history_entry(context, entry)
-                return {"FINISHED"}
+                should_close = self._execute_history_entry(context, entry)
+                if should_close:
+                    self._should_close = True
+                    return {"RUNNING_MODAL"}
+                else:
+                    return {"FINISHED"}
             else:
                 self.report({"WARNING"}, f"No history entry at position '{tok}'")
                 self._finish(context)
@@ -603,8 +689,12 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
             index = extra_map[tok]
             entry = history.get(index)
             if entry:
-                self._execute_history_entry(context, entry)
-                return {"FINISHED"}
+                should_close = self._execute_history_entry(context, entry)
+                if should_close:
+                    self._should_close = True
+                    return {"RUNNING_MODAL"}
+                else:
+                    return {"FINISHED"}
             else:
                 self.report({"WARNING"}, f"No history entry at position '{tok}'")
                 self._finish(context)
@@ -621,8 +711,12 @@ class CHORDSONG_OT_Recents(bpy.types.Operator):
             index = punct_map[tok]
             entry = history.get(index)
             if entry:
-                self._execute_history_entry(context, entry)
-                return {"FINISHED"}
+                should_close = self._execute_history_entry(context, entry)
+                if should_close:
+                    self._should_close = True
+                    return {"RUNNING_MODAL"}
+                else:
+                    return {"FINISHED"}
             else:
                 self.report({"WARNING"}, f"No history entry at position '{tok}'")
                 self._finish(context)

--- a/ui/default_mappings.json
+++ b/ui/default_mappings.json
@@ -1,467 +1,460 @@
 {
-    "version": 1,
-    "scripts_folder": "",
-    "leader_key": "SPACE",
-    "overlay": {
-        "enabled": true,
-        "fading_enabled": true,
-        "show_header": true,
-        "show_footer": true,
-        "max_items": 100,
-        "column_rows": 15,
-        "font_size_header": 12,
-        "font_size_chord": 18,
-        "font_size_body": 15,
-        "font_size_footer": 12,
-        "font_size_fading": 24,
-        "font_size_toggle": 23,
-        "toggle_offset_y": -6,
-        "color_chord": [
-            0.3914475440979004,
-            0.6429893374443054,
-            0.8464089632034302,
-            1.0
-        ],
-        "color_label": [
-            1.0,
-            1.0,
-            1.0,
-            1.0
-        ],
-        "color_header": [
-            1.0,
-            1.0,
-            1.0,
-            1.0
-        ],
-        "color_icon": [
-            0.3914475440979004,
-            0.6429893374443054,
-            0.8464089632034302,
-            1.0
-        ],
-        "color_toggle_on": [
-            0.1739487498998642,
-            1.0,
-            0.76335209608078,
-            1.0
-        ],
-        "color_toggle_off": [
-            0.9646492004394531,
-            0.6671714782714844,
-            0.30953386425971985,
-            0.5
-        ],
-        "color_recents_hotkey": [
-            0.6499999761581421,
-            0.800000011920929,
-            1.0,
-            1.0
-        ],
-        "color_list_background": [
-            0.042096495628356934,
-            0.04517610743641853,
-            0.05087645351886749,
-            0.5
-        ],
-        "color_header_background": [
-            0.08225114643573761,
-            0.08862298727035522,
-            0.10047036409378052,
-            1.0
-        ],
-        "color_footer_background": [
-            0.08225297182798386,
-            0.08862846344709396,
-            0.10047505795955658,
-            1.0
-        ],
-        "gap": 10,
-        "column_gap": 30,
-        "line_height": 1.5,
-        "footer_gap": 50,
-        "footer_token_gap": 4,
-        "footer_label_gap": 8,
-        "position": "BOTTOM_LEFT",
-        "style": "HYBRID",
-        "offset_x": 65,
-        "offset_y": -15,
-        "ungrouped_expanded": true
-    },
-    "groups": [
-        {
-            "name": "Mesh",
-            "display_order": 0,
-            "expanded": true
-        },
-        {
-            "name": "Toggle",
-            "display_order": 1,
-            "expanded": false
-        },
-        {
-            "name": "Vector Math",
-            "display_order": 3,
-            "expanded": false
-        },
-        {
-            "name": "Chord Song",
-            "display_order": 0,
-            "expanded": false
-        },
-        {
-            "name": "Node",
-            "display_order": 4,
-            "expanded": false
-        },
-        {
-            "name": "Math",
-            "display_order": 5,
-            "expanded": false
-        }
+  "version": 1,
+  "scripts_folder": "",
+  "leader_key": "SPACE",
+  "overlay": {
+    "enabled": true,
+    "fading_enabled": true,
+    "show_header": true,
+    "show_footer": true,
+    "max_items": 100,
+    "column_rows": 15,
+    "font_size_header": 12,
+    "font_size_chord": 18,
+    "font_size_body": 15,
+    "font_size_footer": 12,
+    "font_size_fading": 24,
+    "font_size_toggle": 23,
+    "toggle_offset_y": -6,
+    "color_chord": [
+      0.3914475440979004, 0.6429893374443054, 0.8464089632034302, 1.0
     ],
-    "mappings": [
+    "color_label": [1.0, 1.0, 1.0, 1.0],
+    "color_header": [1.0, 1.0, 1.0, 1.0],
+    "color_icon": [
+      0.3914475440979004, 0.6429893374443054, 0.8464089632034302, 1.0
+    ],
+    "color_toggle_on": [0.1739487498998642, 1.0, 0.76335209608078, 1.0],
+    "color_toggle_off": [
+      0.9646492004394531, 0.6671714782714844, 0.30953386425971985, 0.5
+    ],
+    "color_recents_hotkey": [0.6499999761581421, 0.800000011920929, 1.0, 1.0],
+    "color_list_background": [
+      0.042096495628356934, 0.04517610743641853, 0.05087645351886749, 0.5
+    ],
+    "color_header_background": [
+      0.08225114643573761, 0.08862298727035522, 0.10047036409378052, 1.0
+    ],
+    "color_footer_background": [
+      0.08225297182798386, 0.08862846344709396, 0.10047505795955658, 1.0
+    ],
+    "gap": 10,
+    "column_gap": 30,
+    "line_height": 1.5,
+    "footer_gap": 50,
+    "footer_token_gap": 4,
+    "footer_label_gap": 8,
+    "position": "BOTTOM_LEFT",
+    "style": "HYBRID",
+    "offset_x": 65,
+    "offset_y": -15,
+    "ungrouped_expanded": true
+  },
+  "groups": [
+    {
+      "name": "Mesh",
+      "display_order": 0,
+      "expanded": true
+    },
+    {
+      "name": "Toggle",
+      "display_order": 1,
+      "expanded": false
+    },
+    {
+      "name": "Vector Math",
+      "display_order": 3,
+      "expanded": false
+    },
+    {
+      "name": "Chord Song",
+      "display_order": 0,
+      "expanded": false
+    },
+    {
+      "name": "Node",
+      "display_order": 4,
+      "expanded": false
+    },
+    {
+      "name": "Math",
+      "display_order": 5,
+      "expanded": false
+    }
+  ],
+  "mappings": [
+    {
+      "enabled": true,
+      "chord": "a 1",
+      "label": "Cube",
+      "icon": "󰆧",
+      "group": "Mesh",
+      "context": "VIEW_3D",
+      "mapping_type": "OPERATOR",
+      "operators": [
         {
-            "enabled": true,
-            "chord": "a 1",
-            "label": "Cube",
-            "icon": "󰆧",
-            "group": "Mesh",
-            "context": "VIEW_3D",
-            "mapping_type": "OPERATOR",
-            "operators": [
-                {
-                    "operator": "mesh.primitive_cube_add",
-                    "call_context": "INVOKE_DEFAULT",
-                    "kwargs": {}
-                }
-            ]
-        },
-        {
-            "enabled": true,
-            "chord": "a 2",
-            "label": "UV Sphere",
-            "icon": "",
-            "group": "Mesh",
-            "context": "VIEW_3D",
-            "mapping_type": "OPERATOR",
-            "operators": [
-                {
-                    "operator": "mesh.primitive_uv_sphere_add",
-                    "call_context": "INVOKE_DEFAULT",
-                    "kwargs": {}
-                }
-            ]
-        },
-        {
-            "enabled": true,
-            "chord": "k c",
-            "label": "Chord Song Prefs",
-            "icon": "",
-            "group": "Chord Song",
-            "context": "ALL",
-            "mapping_type": "OPERATOR",
-            "operators": [
-                {
-                    "operator": "chordsong.open_prefs",
-                    "call_context": "EXEC_DEFAULT",
-                    "kwargs": 
-                        {
-                            "addon": "chordsong"
-                        }
-                }
-            ]
-        },
-        {
-            "enabled": true,
-            "chord": "x",
-            "label": "Scripts Overlay",
-            "icon": "󰌠",
-            "group": "Chord Song",
-            "context": "ALL",
-            "mapping_type": "OPERATOR",
-            "operators": [
-                {
-                    "operator": "chordsong.scripts_overlay",
-                    "call_context": "INVOKE_DEFAULT",
-                    "kwargs": {}
-                }
-            ]
-        },
-        {
-            "enabled": true,
-            "chord": "a 3",
-            "label": "Cylinder",
-            "icon": "󱥎",
-            "group": "Mesh",
-            "context": "VIEW_3D",
-            "mapping_type": "OPERATOR",
-            "operators": [
-                {
-                    "operator": "mesh.primitive_cylinder_add",
-                    "call_context": "INVOKE_DEFAULT",
-                    "kwargs": {}
-                }
-            ]
-        },
-        {
-            "enabled": true,
-            "chord": "a 4",
-            "label": "Cone",
-            "icon": "󱥌",
-            "group": "Mesh",
-            "context": "VIEW_3D",
-            "mapping_type": "OPERATOR",
-            "operators": [
-                {
-                    "operator": "mesh.primitive_cone_add",
-                    "call_context": "INVOKE_DEFAULT",
-                    "kwargs": {}
-                }
-            ]
-        },
-        {
-            "enabled": true,
-            "chord": "b 1",
-            "label": "Bevel 4",
-            "icon": "󰘇",
-            "group": "Mesh",
-            "context": "VIEW_3D_EDIT",
-            "mapping_type": "OPERATOR",
-            "operators": [
-                {
-                    "operator": "mesh.bevel",
-                    "call_context": "EXEC_DEFAULT",
-                    "kwargs": {
-                        "segments": 4,
-                        "offset": 0.1
-                    }
-                }
-            ]
-        },
-        {
-            "enabled": true,
-            "chord": "b 2",
-            "label": "Bevel 6",
-            "icon": "󰘇",
-            "group": "Mesh",
-            "context": "VIEW_3D_EDIT",
-            "mapping_type": "OPERATOR",
-            "operators": [
-                {
-                    "operator": "mesh.bevel",
-                    "call_context": "EXEC_DEFAULT",
-                    "kwargs": {
-                        "segments": 6,
-                        "offset": 0.2
-                    }
-                }
-            ]
-        },
-        {
-            "enabled": true,
-            "chord": "b 3",
-            "label": "Bevel 8",
-            "icon": "󰘇",
-            "group": "Mesh",
-            "context": "VIEW_3D_EDIT",
-            "mapping_type": "OPERATOR",
-            "operators": [
-                {
-                    "operator": "mesh.bevel",
-                    "call_context": "EXEC_DEFAULT",
-                    "kwargs": {
-                        "segments": 8,
-                        "offset": 0.4
-                    }
-                }
-            ]
-        },
-        {
-            "enabled": true,
-            "chord": "b 4",
-            "label": "Bevel 16",
-            "icon": "",
-            "group": "Mesh",
-            "context": "VIEW_3D_EDIT",
-            "mapping_type": "OPERATOR",
-            "operators": [
-                {
-                    "operator": "mesh.bevel",
-                    "call_context": "EXEC_DEFAULT",
-                    "kwargs": {
-                        "segments": 16,
-                        "offset": 1
-                    }
-                }
-            ]
-        },
-        {
-            "enabled": true,
-            "chord": "t 3",
-            "label": "Show 3D Cursor",
-            "icon": "",
-            "group": "Toggle",
-            "context": "VIEW_3D",
-            "mapping_type": "CONTEXT_TOGGLE",
-            "sync_toggles": false,
-            "context_path": "space_data.overlay.show_cursor"
-        },
-        {
-            "enabled": true,
-            "chord": "t b",
-            "label": "Backface Culling",
-            "icon": "",
-            "group": "Toggle",
-            "context": "VIEW_3D",
-            "mapping_type": "CONTEXT_TOGGLE",
-            "sync_toggles": false,
-            "context_path": "space_data.shading.show_backface_culling"
-        },
-        {
-            "enabled": true,
-            "chord": "t o",
-            "label": "Show Overlays",
-            "icon": "",
-            "group": "Toggle",
-            "context": "VIEW_3D",
-            "mapping_type": "CONTEXT_TOGGLE",
-            "sync_toggles": false,
-            "context_path": "space_data.overlay.show_overlays"
-        },
-        {
-            "enabled": true,
-            "chord": "t s",
-            "label": "Show Statistics",
-            "icon": "󰋽",
-            "group": "Toggle",
-            "context": "VIEW_3D",
-            "mapping_type": "CONTEXT_TOGGLE",
-            "sync_toggles": true,
-            "context_path": "space_data.overlay.show_stats",
-            "sub_items": [
-                {
-                    "path": "space_data.overlay.show_text",
-                    "value": ""
-                }
-            ]
-        },
-        {
-            "enabled": true,
-            "chord": "m a",
-            "label": "Add",
-            "icon": "󰎂",
-            "group": "Math",
-            "context": "SHADER_EDITOR",
-            "mapping_type": "PYTHON_FILE",
-            "python_file": "sample_scripts/NODE_Add.py",
-            "kwargs": {
-                "id": "ShaderNodeMath",
-                "operation": "ADD"
-            }
-        },
-        {
-            "enabled": true,
-            "chord": "m m",
-            "label": "Multiply",
-            "icon": "󰎂",
-            "group": "Math",
-            "context": "SHADER_EDITOR",
-            "mapping_type": "PYTHON_FILE",
-            "python_file": "sample_scripts/NODE_Add.py",
-            "kwargs": {
-                "id": "ShaderNodeMath",
-                "operation": "MULTIPLY"
-            }
-        },
-        {
-            "enabled": true,
-            "chord": "m d",
-            "label": "Divide",
-            "icon": "󰎂",
-            "group": "Math",
-            "context": "SHADER_EDITOR",
-            "mapping_type": "PYTHON_FILE",
-            "python_file": "sample_scripts/NODE_Add.py",
-            "kwargs": {
-                "id": "ShaderNodeMath",
-                "operation": "DIVIDE"
-            }
-        },
-        {
-            "enabled": true,
-            "chord": "v a",
-            "label": "Vector Add",
-            "icon": "󰑃",
-            "group": "Vector Math",
-            "context": "SHADER_EDITOR",
-            "mapping_type": "PYTHON_FILE",
-            "python_file": "sample_scripts/NODE_Add.py",
-            "kwargs": {
-                "id": "ShaderNodeVectorMath",
-                "operation": "ADD"
-            }
-        },
-        {
-            "enabled": true,
-            "chord": "v m",
-            "label": "Vector Mulitply",
-            "icon": "󰑃 󰎂",
-            "group": "Vector Math",
-            "context": "SHADER_EDITOR",
-            "mapping_type": "PYTHON_FILE",
-            "python_file": "sample_scripts/NODE_Add.py",
-            "kwargs": {
-                "id": "ShaderNodeVectorMath",
-                "operation": "MULTIPLY"
-            }
-        },
-        {
-            "enabled": true,
-            "chord": "v s",
-            "label": "Vector Subtract",
-            "icon": "󰑃",
-            "group": "Vector Math",
-            "context": "SHADER_EDITOR",
-            "mapping_type": "PYTHON_FILE",
-            "python_file": "sample_scripts/NODE_Add.py",
-            "kwargs": {
-                "id": "ShaderNodeVectorMath",
-                "operation": "SUBTRACT"
-            }
-        },
-        {
-            "enabled": true,
-            "chord": "v d",
-            "label": "Vector Divide",
-            "icon": "󰑃",
-            "group": "Vector Math",
-            "context": "SHADER_EDITOR",
-            "mapping_type": "PYTHON_FILE",
-            "python_file": "sample_scripts/NODE_Add.py",
-            "kwargs": {
-                "id": "ShaderNodeVectorMath",
-                "operation": "DIVIDE"
-            }
-        },
-        {
-            "enabled": true,
-            "chord": "b",
-            "label": "Bevel",
-            "icon": "",
-            "group": "Node",
-            "context": "SHADER_EDITOR",
-            "mapping_type": "OPERATOR",
-            "operators": [
-                {
-                    "operator": "node.add_node",
-                    "call_context": "INVOKE_DEFAULT",
-                    "kwargs": {
-                        "type": "ShaderNodeBevel",
-                        "use_transform": false
-                    }
-                }
-            ]
+          "operator": "mesh.primitive_cube_add",
+          "call_context": "INVOKE_DEFAULT",
+          "kwargs": {}
         }
-    ]
+      ]
+    },
+    {
+      "enabled": true,
+      "chord": "a 2",
+      "label": "UV Sphere",
+      "icon": "",
+      "group": "Mesh",
+      "context": "VIEW_3D",
+      "mapping_type": "OPERATOR",
+      "operators": [
+        {
+          "operator": "mesh.primitive_uv_sphere_add",
+          "call_context": "INVOKE_DEFAULT",
+          "kwargs": {}
+        }
+      ]
+    },
+    {
+      "enabled": true,
+      "chord": "k c",
+      "label": "Chord Song Prefs",
+      "icon": "",
+      "group": "Chord Song",
+      "context": "ALL",
+      "mapping_type": "OPERATOR",
+      "operators": [
+        {
+          "operator": "chordsong.open_prefs",
+          "call_context": "EXEC_DEFAULT",
+          "kwargs": {
+            "addon": "chordsong"
+          }
+        }
+      ]
+    },
+    {
+      "enabled": true,
+      "chord": "x",
+      "label": "Scripts Overlay",
+      "icon": "󰌠",
+      "group": "Chord Song",
+      "context": "ALL",
+      "mapping_type": "OPERATOR",
+      "operators": [
+        {
+          "operator": "chordsong.scripts_overlay",
+          "call_context": "INVOKE_DEFAULT",
+          "kwargs": {}
+        }
+      ]
+    },
+    {
+      "enabled": true,
+      "chord": "a 3",
+      "label": "Cylinder",
+      "icon": "󱥎",
+      "group": "Mesh",
+      "context": "VIEW_3D",
+      "mapping_type": "OPERATOR",
+      "operators": [
+        {
+          "operator": "mesh.primitive_cylinder_add",
+          "call_context": "INVOKE_DEFAULT",
+          "kwargs": {}
+        }
+      ]
+    },
+    {
+      "enabled": true,
+      "chord": "a 4",
+      "label": "Cone",
+      "icon": "󱥌",
+      "group": "Mesh",
+      "context": "VIEW_3D",
+      "mapping_type": "OPERATOR",
+      "operators": [
+        {
+          "operator": "mesh.primitive_cone_add",
+          "call_context": "INVOKE_DEFAULT",
+          "kwargs": {}
+        }
+      ]
+    },
+    {
+      "enabled": true,
+      "chord": "b 1",
+      "label": "Bevel 4",
+      "icon": "󰘇",
+      "group": "Mesh",
+      "context": "VIEW_3D_EDIT",
+      "mapping_type": "OPERATOR",
+      "operators": [
+        {
+          "operator": "mesh.bevel",
+          "call_context": "EXEC_DEFAULT",
+          "kwargs": {
+            "segments": 4,
+            "offset": 0.1
+          }
+        }
+      ]
+    },
+    {
+      "enabled": true,
+      "chord": "b 2",
+      "label": "Bevel 6",
+      "icon": "󰘇",
+      "group": "Mesh",
+      "context": "VIEW_3D_EDIT",
+      "mapping_type": "OPERATOR",
+      "operators": [
+        {
+          "operator": "mesh.bevel",
+          "call_context": "EXEC_DEFAULT",
+          "kwargs": {
+            "segments": 6,
+            "offset": 0.2
+          }
+        }
+      ]
+    },
+    {
+      "enabled": true,
+      "chord": "b 3",
+      "label": "Bevel 8",
+      "icon": "󰘇",
+      "group": "Mesh",
+      "context": "VIEW_3D_EDIT",
+      "mapping_type": "OPERATOR",
+      "operators": [
+        {
+          "operator": "mesh.bevel",
+          "call_context": "EXEC_DEFAULT",
+          "kwargs": {
+            "segments": 8,
+            "offset": 0.4
+          }
+        }
+      ]
+    },
+    {
+      "enabled": true,
+      "chord": "b 4",
+      "label": "Bevel 16",
+      "icon": "",
+      "group": "Mesh",
+      "context": "VIEW_3D_EDIT",
+      "mapping_type": "OPERATOR",
+      "operators": [
+        {
+          "operator": "mesh.bevel",
+          "call_context": "EXEC_DEFAULT",
+          "kwargs": {
+            "segments": 16,
+            "offset": 1
+          }
+        }
+      ]
+    },
+    {
+      "enabled": true,
+      "chord": "t 3",
+      "label": "Show 3D Cursor",
+      "icon": "",
+      "group": "Toggle",
+      "context": "VIEW_3D",
+      "mapping_type": "CONTEXT_TOGGLE",
+      "sync_toggles": false,
+      "context_path": "space_data.overlay.show_cursor"
+    },
+    {
+      "enabled": true,
+      "chord": "t b",
+      "label": "Backface Culling",
+      "icon": "",
+      "group": "Toggle",
+      "context": "VIEW_3D",
+      "mapping_type": "CONTEXT_TOGGLE",
+      "sync_toggles": false,
+      "context_path": "space_data.shading.show_backface_culling"
+    },
+    {
+      "enabled": true,
+      "chord": "t o",
+      "label": "Show Overlays",
+      "icon": "",
+      "group": "Toggle",
+      "context": "VIEW_3D",
+      "mapping_type": "CONTEXT_TOGGLE",
+      "sync_toggles": false,
+      "context_path": "space_data.overlay.show_overlays"
+    },
+    {
+      "enabled": true,
+      "chord": "t s",
+      "label": "Show Statistics",
+      "icon": "󰋽",
+      "group": "Toggle",
+      "context": "VIEW_3D",
+      "mapping_type": "CONTEXT_TOGGLE",
+      "sync_toggles": true,
+      "context_path": "space_data.overlay.show_stats",
+      "sub_items": [
+        {
+          "path": "space_data.overlay.show_text",
+          "value": ""
+        }
+      ]
+    },
+    {
+      "enabled": true,
+      "chord": "m a",
+      "label": "Add",
+      "icon": "󰎂",
+      "group": "Math",
+      "context": "SHADER_EDITOR",
+      "mapping_type": "PYTHON_FILE",
+      "python_file": "sample_scripts/NODE_Add.py",
+      "kwargs": {
+        "id": "ShaderNodeMath",
+        "operation": "ADD"
+      }
+    },
+    {
+      "enabled": true,
+      "chord": "m m",
+      "label": "Multiply",
+      "icon": "󰎂",
+      "group": "Math",
+      "context": "SHADER_EDITOR",
+      "mapping_type": "PYTHON_FILE",
+      "python_file": "sample_scripts/NODE_Add.py",
+      "kwargs": {
+        "id": "ShaderNodeMath",
+        "operation": "MULTIPLY"
+      }
+    },
+    {
+      "enabled": true,
+      "chord": "m d",
+      "label": "Divide",
+      "icon": "󰎂",
+      "group": "Math",
+      "context": "SHADER_EDITOR",
+      "mapping_type": "PYTHON_FILE",
+      "python_file": "sample_scripts/NODE_Add.py",
+      "kwargs": {
+        "id": "ShaderNodeMath",
+        "operation": "DIVIDE"
+      }
+    },
+    {
+      "enabled": true,
+      "chord": "v a",
+      "label": "Vector Add",
+      "icon": "󰑃",
+      "group": "Vector Math",
+      "context": "SHADER_EDITOR",
+      "mapping_type": "PYTHON_FILE",
+      "python_file": "sample_scripts/NODE_Add.py",
+      "kwargs": {
+        "id": "ShaderNodeVectorMath",
+        "operation": "ADD"
+      }
+    },
+    {
+      "enabled": true,
+      "chord": "v m",
+      "label": "Vector Mulitply",
+      "icon": "󰑃 󰎂",
+      "group": "Vector Math",
+      "context": "SHADER_EDITOR",
+      "mapping_type": "PYTHON_FILE",
+      "python_file": "sample_scripts/NODE_Add.py",
+      "kwargs": {
+        "id": "ShaderNodeVectorMath",
+        "operation": "MULTIPLY"
+      }
+    },
+    {
+      "enabled": true,
+      "chord": "v s",
+      "label": "Vector Subtract",
+      "icon": "󰑃",
+      "group": "Vector Math",
+      "context": "SHADER_EDITOR",
+      "mapping_type": "PYTHON_FILE",
+      "python_file": "sample_scripts/NODE_Add.py",
+      "kwargs": {
+        "id": "ShaderNodeVectorMath",
+        "operation": "SUBTRACT"
+      }
+    },
+    {
+      "enabled": true,
+      "chord": "v d",
+      "label": "Vector Divide",
+      "icon": "󰑃",
+      "group": "Vector Math",
+      "context": "SHADER_EDITOR",
+      "mapping_type": "PYTHON_FILE",
+      "python_file": "sample_scripts/NODE_Add.py",
+      "kwargs": {
+        "id": "ShaderNodeVectorMath",
+        "operation": "DIVIDE"
+      }
+    },
+    {
+      "enabled": true,
+      "chord": "b",
+      "label": "Bevel",
+      "icon": "",
+      "group": "Node",
+      "context": "SHADER_EDITOR",
+      "mapping_type": "OPERATOR",
+      "operators": [
+        {
+          "operator": "node.add_node",
+          "call_context": "INVOKE_DEFAULT",
+          "kwargs": {
+            "type": "ShaderNodeBevel",
+            "use_transform": false
+          }
+        }
+      ]
+    },
+    {
+      "enabled": true,
+      "chord": "",
+      "label": "Close Overlay",
+      "icon": "󰅖",
+      "group": "Chord Song",
+      "context": "ALL",
+      "mapping_type": "OPERATOR",
+      "operators": [
+        {
+          "operator": "chordsong.close_overlay",
+          "call_context": "EXEC_DEFAULT",
+          "kwargs": {}
+        }
+      ]
+    },
+    {
+      "enabled": true,
+      "chord": "space",
+      "label": "Show Recents",
+      "icon": "󰋚",
+      "group": "Chord Song",
+      "context": "ALL",
+      "mapping_type": "OPERATOR",
+      "operators": [
+        {
+          "operator": "chordsong.recents",
+          "call_context": "INVOKE_DEFAULT",
+          "kwargs": {}
+        }
+      ]
+    }
+  ]
 }

--- a/ui/overlay/layout.py
+++ b/ui/overlay/layout.py
@@ -1,5 +1,5 @@
 """Layout calculation functions for overlay."""
-from ...core.engine import get_leader_key_token
+from ...core.engine import get_leader_key_token, get_str_attr
 from .tokenizer import (
     parse_format_string,
     generate_tokens_for_folder,
@@ -9,19 +9,19 @@ from .tokenizer import (
 
 def _get_preset_formats(style):
     """Get format strings for preset styles.
-    
+
     Each preset maps to specific format strings for folders and items:
     - DEFAULT: Simple count display
       Folder: "a → +5 keymaps"
       Item: "a  Save"
     - CUSTOM: User-defined format strings
-    
+
     Token types:
     - C: Chord, I: Icon, i: Group Icon, G: Groups (all), g: Group (first only)
     - L: Label, N: Count (verbose), n: Count (compact)
     - S: Separator A (→), s: Separator B (::)
     - T: Toggle icon
-    
+
     Returns: (folder_format, item_format, separator_a, separator_b)
     """
     presets = {
@@ -39,10 +39,10 @@ def build_overlay_rows(cands, has_buffer, p=None):
         p: Preferences object (optional)
     """
     rows = []
-    
+
     # Get style from prefs if available
     style = getattr(p, "overlay_item_format", "DEFAULT") if p else "DEFAULT"
-    
+
     # Get format strings based on style
     if style == "CUSTOM" and p:
         # Use user-defined format strings
@@ -57,14 +57,14 @@ def build_overlay_rows(cands, has_buffer, p=None):
             format_folder, format_item, separator_a, separator_b = preset
         else:
             format_folder, format_item, separator_a, separator_b = "C S N", "C I L T", "→", "::"
-    
+
     # Build group icons dictionary from preferences
     group_icons = {}
     if p:
         for grp in p.groups:
             if grp.name and grp.icon:
                 group_icons[grp.name] = grp.icon
-    
+
     # Build group display_order lookup from preferences
     group_order = {}
     if p:
@@ -128,11 +128,11 @@ def build_overlay_rows(cands, has_buffer, p=None):
         return tuple(key)
 
     sorted_cands = sorted(cands, key=_sort_key)
-    
+
     for c in sorted_cands:
         token = c.next_token
         icon = c.icon if c.icon else ""
-        
+
         if c.count > 1 or not c.is_final:
             # Folder/Summary row - use tokenization for all styles
             token_types = parse_format_string(format_folder)
@@ -146,7 +146,7 @@ def build_overlay_rows(cands, has_buffer, p=None):
                 separator_b=separator_b,
                 group_icons=group_icons,
             )
-            
+
             # Store tokens in the row for rendering
             rows.append({
                 "kind": "item",
@@ -181,7 +181,7 @@ def build_overlay_rows(cands, has_buffer, p=None):
                 mapping_type=c.mapping_type,
                 group_icons=group_icons,
             )
-            
+
             rows.append({
                 "kind": "item",
                 "token": token,
@@ -194,16 +194,67 @@ def build_overlay_rows(cands, has_buffer, p=None):
 
     # Footer items (always at bottom)
     footer = []
-    
+
     # 1. Mod hints (informational)
     footer.append({"kind": "hint", "token": ">R  ^Ctrl  !Alt  +Shift  #Win", "label": "", "icon": ""})
 
     if not has_buffer:
         # Only show recents at root level (no buffer)
-        leader_token = get_leader_key_token()
-        footer.append({"kind": "item", "token": f"{leader_token}+{leader_token}", "label": "Recent Commands", "icon": ""})
+        # Find single-token Recents chords only (no spaces)
+        recents_chords = []
+        if p:
+            for m in p.mappings:
+                if getattr(m, "mapping_type", "OPERATOR") == "OPERATOR":
+                    if get_str_attr(m, "operator") == "chordsong.recents" and getattr(m, "enabled", True):
+                        chord = get_str_attr(m, "chord")
+                        # Only include single-token chords (no spaces)
+                        if chord and " " not in chord:
+                            recents_chords.append(chord)
 
-    footer.append({"kind": "item", "token": "ESC", "label": "Close", "icon": ""})
+        if recents_chords:
+            # Use the first single-token chord
+            display_chord = recents_chords[0].replace(" ", "+")
+            footer.append({"kind": "item", "token": display_chord, "label": "Recent Commands", "icon": ""})
+        else:
+            # Fallback to original behavior (double leader)
+            leader_token = get_leader_key_token()
+            footer.append({"kind": "item", "token": f"{leader_token}+{leader_token}", "label": "Recent Commands", "icon": ""})
+
+    # Close button with optional custom close chord (dynamic based on whether close key is a valid next token)
+    # Find single-token Close Overlay chords (no spaces)
+    close_chords = []
+    if p:
+        for m in p.mappings:
+            if getattr(m, "mapping_type", "OPERATOR") == "OPERATOR":
+                if get_str_attr(m, "operator") == "chordsong.close_overlay" and getattr(m, "enabled", True):
+                    chord = get_str_attr(m, "chord")
+                    # Only include single-token chords (no spaces)
+                    if chord and " " not in chord:
+                        close_chords.append(chord)
+
+    if close_chords:
+        if not has_buffer:
+            # At root level, close is always available
+            display_chord = close_chords[0].replace(" ", "+")
+            footer.append({"kind": "item", "token": f"ESC|{display_chord}", "label": "Close", "icon": ""})
+        else:
+            # Check if any close chord appears as a candidate for the next token
+            close_key_available = False
+            for c in cands:
+                if c.next_token in close_chords:
+                    close_key_available = True
+                    break
+
+            if close_key_available:
+                # Close key is a valid next token, so it won't close
+                footer.append({"kind": "item", "token": "ESC", "label": "Close", "icon": ""})
+            else:
+                # Close key is not a valid next token, so it would close
+                display_chord = close_chords[0].replace(" ", "+")
+                footer.append({"kind": "item", "token": f"ESC|{display_chord}", "label": "Close", "icon": ""})
+    else:
+        footer.append({"kind": "item", "token": "ESC", "label": "Close", "icon": ""})
+
     if has_buffer:
         footer.append({"kind": "item", "token": "BS", "label": "Back", "icon": ""})
 
@@ -230,16 +281,16 @@ def wrap_into_columns(rows, max_rows):
 
 def calculate_column_widths(columns, footer, chord_size, body_size, p=None):
     """Calculate token and label widths per column and for footer.
-    
+
     Each format token type becomes its own sub-column with calculated width.
     """
     import blf  # type: ignore
 
     column_metrics = []
-    
+
     # Get max label length setting for truncation during width calculation
     max_label_length = getattr(p, "overlay_max_label_length", 0) if p else 0
-    
+
     # Get font sizes for different token types
     icon_size = chord_size
     toggle_size = max(int(getattr(p, "overlay_font_size_toggle", 16)), 6) if p else 16
@@ -251,7 +302,7 @@ def calculate_column_widths(columns, footer, chord_size, body_size, p=None):
     for col in columns:
         # Dynamic sub-columns: track max width for each token type
         token_widths = {}  # token_type -> max_width
-        
+
         # Legacy fields
         col_max_header_w = 0.0
         has_any_icon = False
@@ -277,7 +328,7 @@ def calculate_column_widths(columns, footer, chord_size, body_size, p=None):
                             blf.size(0, toggle_size)
                         else:  # G, g, L, N, n, S, s - use body size
                             blf.size(0, body_size)
-                        
+
                         # Apply truncation for label tokens
                         content = tok.content
                         if tok.type == 'L' and max_label_length > 0 and len(content) > max_label_length:
@@ -285,10 +336,10 @@ def calculate_column_widths(columns, footer, chord_size, body_size, p=None):
                                 content = content[:max_label_length-3] + "..."
                             else:
                                 content = content[:max_label_length]
-                        
+
                         # Measure width
                         w, _ = blf.dimensions(0, content)
-                        
+
                         # Track maximum width for this token type
                         token_widths[tok.type] = max(token_widths.get(tok.type, 0.0), w)
                 else:
@@ -299,7 +350,7 @@ def calculate_column_widths(columns, footer, chord_size, body_size, p=None):
                         has_any_icon = True
                         iw, _ = blf.dimensions(0, r["icon"])
                         token_widths['I'] = max(token_widths.get('I', 0.0), iw)
-                    
+
                     tw, _ = blf.dimensions(0, f"{r['token'].upper()}")
                     token_widths['C'] = max(token_widths.get('C', 0.0), tw)
 
@@ -308,23 +359,23 @@ def calculate_column_widths(columns, footer, chord_size, body_size, p=None):
                     full_txt = r["label"]
                     if r.get("label_extra"):
                         full_txt += "  " + r["label_extra"]
-                    
+
                     # Extract label without toggle icons
                     label_txt = full_txt
                     for toggle_icon in ["  󰨚", "  󰨙", "󰨚", "󰨙"]:
                         label_txt = label_txt.replace(toggle_icon, "")
                     label_txt = label_txt.rstrip()
-                    
+
                     # Apply max_label_length truncation
                     if max_label_length > 0 and len(label_txt) > max_label_length:
                         if max_label_length > 3:
                             label_txt = label_txt[:max_label_length-3] + "..."
                         else:
                             label_txt = label_txt[:max_label_length]
-                    
+
                     lw, _ = blf.dimensions(0, label_txt)
                     token_widths['L'] = max(token_widths.get('L', 0.0), lw)
-                    
+
                     # Toggle column
                     if r.get("mapping_type") == "CONTEXT_TOGGLE":
                         blf.size(0, toggle_size)
@@ -332,7 +383,7 @@ def calculate_column_widths(columns, footer, chord_size, body_size, p=None):
                         tw_off, _ = blf.dimensions(0, "󰨙")
                         toggle_w = max(tw_on, tw_off)
                         token_widths['T'] = max(token_widths.get('T', 0.0), toggle_w)
-                
+
                 blf.size(0, chord_size)
 
         # Build metrics dict with dynamic token widths

--- a/ui/prefs.py
+++ b/ui/prefs.py
@@ -53,7 +53,7 @@ def default_config_path() -> str:
         except Exception:
             # Silently fallback if extension_path_user fails
             pass
-    
+
     # Fallback to user_resource if extension_path_user is not available
     # (for backward compatibility with older Blender versions)
     # Note: This respects BLENDER_USER_RESOURCES and BLENDER_USER_SCRIPTS env vars
@@ -96,7 +96,7 @@ def _check_conflicts_silent(context):
     try:
         from ..operators.check_conflicts import CHORDSONG_OT_CheckConflicts, find_conflicts
         prefs = context.preferences.addons[_addon_root_pkg()].preferences
-        
+
         conflicts = find_conflicts(prefs.mappings)
         CHORDSONG_OT_CheckConflicts.conflicts = conflicts
     except Exception:
@@ -108,7 +108,7 @@ def _on_prefs_changed(self, _context):
         # Skip callbacks during bulk operations (config loading, etc.)
         if _SUSPEND_CALLBACKS:
             return
-        
+
         self.ensure_defaults()
         _autosave_now(self)
     except Exception:
@@ -119,18 +119,18 @@ def _on_mapping_changed(_self, context):
         # Skip callbacks during bulk operations (config loading, etc.)
         if _SUSPEND_CALLBACKS:
             return
-        
+
         prefs = context.preferences.addons[_addon_root_pkg()].preferences
         prefs.ensure_defaults()
         _autosave_now(prefs)
-        
+
         # Clear overlay cache so changes appear immediately
         from .overlay import clear_overlay_cache
         clear_overlay_cache()
-        
+
         # Sync groups after a short delay to avoid crashing during rapid typing/redraws
         prefs.sync_groups_delayed()
-        
+
         # Check conflicts silently to update UI highlighting
         _check_conflicts_silent(context)
     except Exception:
@@ -142,7 +142,7 @@ def _on_group_changed(_self, context):
         # Skip callbacks during bulk operations (config loading, etc.)
         if _SUSPEND_CALLBACKS:
             return
-        
+
         prefs = context.preferences.addons[_addon_root_pkg()].preferences
         _autosave_now(prefs)
     except Exception:
@@ -167,7 +167,7 @@ def clear_operator_cache():
 def _build_operator_cache():
     """
     Build cached list of all operator idnames.
-    
+
     Note: Cache persists until explicitly cleared. Operators registered/unregistered
     after cache creation won't appear until cache is cleared. This is acceptable
     since operator registration typically happens at addon enable time.
@@ -177,10 +177,10 @@ def _build_operator_cache():
         # Return cached list if available
         if _operator_cache is not None:
             return _operator_cache
-        
+
         operators = []
         seen = set()
-        
+
         # Iterate through bpy.ops modules (most reliable method)
         # Cache module names to avoid repeated dir() calls
         try:
@@ -188,7 +188,7 @@ def _build_operator_cache():
         except Exception:
             # Fallback: return empty list if bpy.ops is not accessible
             return []
-        
+
         for module_name in op_modules:
             try:
                 op_module = getattr(bpy.ops, module_name)
@@ -205,7 +205,7 @@ def _build_operator_cache():
             except Exception:
                 # Skip any other errors to prevent one bad module from breaking everything
                 continue
-        
+
         _operator_cache = sorted(operators)
         return _operator_cache
     except Exception:
@@ -218,22 +218,22 @@ def _fuzzy_match_operator(query: str, operator_idname: str) -> tuple[bool, int]:
     Normalizes dots and underscores to spaces before matching.
     """
     from ..utils.fuzzy import fuzzy_match
-    
+
     # Normalize: treat dots and underscores as spaces (in addition to what fuzzy_match does)
     query_normalized = query.replace('.', ' ').replace('_', ' ')
     text_normalized = operator_idname.replace('.', ' ').replace('_', ' ')
-    
+
     # Remove extra spaces
     query_normalized = ' '.join(query_normalized.split())
     text_normalized = ' '.join(text_normalized.split())
-    
+
     # Use the existing fuzzy_match function
     return fuzzy_match(query_normalized, text_normalized)
 
 def _operator_search_callback(_self, _context, edit_text):
     """
     Search callback for operator idname field - provides Blender's operator search.
-    
+
     Returns a list of operator idnames matching the search text.
     Uses cached operator list for performance.
     Supports fuzzy matching: "add op" will match "addon.operator"
@@ -241,29 +241,29 @@ def _operator_search_callback(_self, _context, edit_text):
     try:
         # Get cached operator list
         all_operators = _build_operator_cache()
-        
+
         if not all_operators:
             # Return empty if cache building failed
             return []
-        
+
         if not edit_text:
             # Return all operators if no search text (limited to prevent UI lag)
             # Limit to first 10 to prevent UI slowdown with very large lists
             return all_operators[:10]
-        
+
         edit_text_clean = edit_text.strip()
-        
+
         # Use fuzzy matching for better search experience
         matched_operators = []
         for op in all_operators:
             matched, score = _fuzzy_match_operator(edit_text_clean, op)
             if matched:
                 matched_operators.append((score, op))
-        
+
         # Sort by score (lower is better) and return just the operator names
         matched_operators.sort(key=lambda x: x[0])
         results = [op for _, op in matched_operators]
-        
+
         # Limit results to prevent UI lag with very broad searches
         # 50 is a reasonable limit that still shows plenty of results
         return results[:50]
@@ -614,7 +614,7 @@ class CHORDSONG_Preferences(AddonPreferences):
         default=True,
         update=_on_prefs_changed,
     )
-    
+
     toggle_multi_modifier: EnumProperty(
         name="Multi-Toggle Modifier",
         description="Hold this modifier while executing a toggle to keep overlay open for multiple toggles",
@@ -939,7 +939,7 @@ class CHORDSONG_Preferences(AddonPreferences):
         default="DEFAULT",
         update=_on_prefs_changed,
     )
-    
+
     # Custom format strings
     overlay_format_folder: StringProperty(
         name="Folder Format",
@@ -950,7 +950,7 @@ class CHORDSONG_Preferences(AddonPreferences):
         default="C n s G L",
         update=_on_prefs_changed,
     )
-    
+
     overlay_format_item: StringProperty(
         name="Item Format",
         description=(
@@ -960,21 +960,21 @@ class CHORDSONG_Preferences(AddonPreferences):
         default="C I S L T",
         update=_on_prefs_changed,
     )
-    
+
     overlay_separator_a: StringProperty(
         name="Separator A",
         description="Primary separator (used by S token)",
         default="→",
         update=_on_prefs_changed,
     )
-    
+
     overlay_separator_b: StringProperty(
-        name="Separator B", 
+        name="Separator B",
         description="Secondary separator (used by s token)",
         default="::",
         update=_on_prefs_changed,
     )
-    
+
     overlay_max_label_length: IntProperty(
         name="Max Label Length",
         description="Maximum character length for labels before truncation. The longest label in each column sets the width for toggle icon alignment. Set to 0 for no limit.",
@@ -1034,6 +1034,24 @@ class CHORDSONG_Preferences(AddonPreferences):
         update=_on_prefs_changed,
     )
 
+    # ============================================================
+    # MIGRATION CODE: double-leader Recents notification
+    # ============================================================
+    # TO REMOVE LATER ON: just delete all "MIGRATION CODE" blocks in this file as
+    # well as in operators/leader.py.
+    #
+    # N.B. Also delete the _show_recents_migration_notice function in leader.py, and the
+    # recents_notice_dismissed property in prefs.py (this property).
+    # ============================================================
+    recents_notice_dismissed: BoolProperty(
+        name="Recents Notice Dismissed",
+        default=False,
+        options={"HIDDEN"},
+    )
+    # ============================================================
+    # END MIGRATION CODE
+    # ============================================================
+
     def ensure_defaults(self):
         """Ensure default config path and nerd icons are initialized."""
         # Only set config_path if it's truly empty (first time setup)
@@ -1057,7 +1075,7 @@ class CHORDSONG_Preferences(AddonPreferences):
         if CHORDSONG_Preferences._sync_timer_fn:
             if bpy.app.timers.is_registered(CHORDSONG_Preferences._sync_timer_fn):
                 bpy.app.timers.unregister(CHORDSONG_Preferences._sync_timer_fn)
-        
+
         def run_sync():
             try:
                 # We need to re-fetch prefs since self might be invalid if reloaded
@@ -1092,19 +1110,19 @@ class CHORDSONG_Preferences(AddonPreferences):
             name = (getattr(m, "group", "") or "").strip()
             if name:
                 used_names.add(name)
-        
+
         # 2. Collect current names in the groups collection
         existing_names = {grp.name for grp in self.groups if grp.name}
-        
+
         # 3. Determine changes
         to_add = used_names - existing_names
         to_remove = set()
         if remove_unused:
             to_remove = existing_names - used_names
-        
+
         # 4. Apply changes surgically
         has_changes = False
-        
+
         # Removing first (reverse order to preserve indices)
         if to_remove:
             for i in range(len(self.groups) - 1, -1, -1):
@@ -1124,8 +1142,8 @@ class CHORDSONG_Preferences(AddonPreferences):
 
     def _sort_groups(self):
         """Preserve user-defined group order (no longer auto-sorts).
-        
-        Previously sorted alphabetically, but now users can manually 
+
+        Previously sorted alphabetically, but now users can manually
         reorder groups with up/down buttons. New groups are added at the end.
         """
         # No longer auto-sort - preserve user order

--- a/utils/render.py
+++ b/utils/render.py
@@ -124,19 +124,19 @@ def calculate_scale_factor(context) -> float:
     try:
         # Access preferences via bpy.context for robustness in draw handlers
         prefs = bpy.context.preferences
-        
+
         # Respect UI Scale (System > Interface > Resolution Scale)
         # Note: view.ui_scale is often 1.0, while system.dpi reflects the Resolution Scale.
         ui_scale = getattr(prefs.view, "ui_scale", 1.0)
-        
+
         # Respect DPI (System > Interface > Resolution Scale also affects this)
-        # Standard DPI is 72. 
+        # Standard DPI is 72.
         dpi = prefs.system.dpi
-        
+
         # Respect Pixel Size (1 for standard, 2 for Retina/HighDPI)
         # This is the most reliable way to scale for High DPI.
         pixel_size = getattr(prefs.system, "pixel_size", 1.0)
-        
+
         # Respect Line Width (System > Interface > Line Width)
         # This affects the 'thickness' of the UI.
         # Enums: 'THIN', 'AUTO', 'THICK'
@@ -150,10 +150,10 @@ def calculate_scale_factor(context) -> float:
 
         # Base scale factor combines DPI and UI scale
         scale = ui_scale * (dpi / 72.0)
-        
+
         # Ensure it's at least pixel_size
         scale = max(scale, pixel_size)
-        
+
         return scale * line_width_mult
     except Exception:
         try:
@@ -275,17 +275,10 @@ def _run_single_operator(opfn, call_ctx, kwargs, valid_ctx):
 
 
 def execute_history_entry_operator(context, entry):
-    """Execute the full operator chain from a history entry.
-
-    Returns:
-        tuple: (success: bool, error_message: str or None)
-    """
     try:
         if hasattr(entry, 'execution_context') and entry.execution_context:
             ctx_viewport = entry.execution_context
             valid_ctx = validate_viewport_context(ctx_viewport)
-            if not valid_ctx:
-                return False, "Operator area not found"
         else:
             ctx_viewport = capture_viewport_context(context)
             valid_ctx = validate_viewport_context(ctx_viewport) if ctx_viewport else None
@@ -300,26 +293,21 @@ def execute_history_entry_operator(context, entry):
             )
             if result_set and ('FINISHED' in result_set or 'CANCELLED' not in result_set):
                 success = True
-
         return (True, None) if success else (False, None)
-
     except Exception as e:
         import traceback
-        op_label = entry.operators[0]["op"] if entry.operators else "unknown"
-        error_msg = f"Failed to execute operator {op_label}: {e}"
-        print(f"Chord Song: {error_msg}")
         traceback.print_exc()
-        return False, error_msg
+        return False, str(e)
 
 def _execute_script_via_text_editor(filepath, script_args=None, valid_ctx=None, context=None):
     """Execute a Python script using Blender's text editor (avoids exec/runpy).
-    
+
     Args:
         filepath: Path to the Python script file
         script_args: Optional dictionary of arguments to pass as 'args' global
         valid_ctx: Optional validated viewport context dictionary
         context: Blender context (required for preference check)
-        
+
     Returns:
         tuple: (success: bool, error_message: str or None)
     """
@@ -328,16 +316,16 @@ def _execute_script_via_text_editor(filepath, script_args=None, valid_ctx=None, 
         from ..operators.common import prefs
         if not prefs(context).allow_custom_user_scripts:
             return False, "Script execution is disabled. Enable 'Allow Custom User Scripts' in Preferences."
-    
+
     try:
         import os
         if not os.path.exists(filepath):
             return False, f"Script file not found: {filepath}"
-        
+
         # Read the script file
         with open(filepath, 'r', encoding='utf-8') as f:
             script_content = f.read()
-        
+
         # Prepend code to set up globals (args, context)
         # This allows scripts to access 'args' dictionary and ensures 'context' is available
         import json
@@ -345,24 +333,24 @@ def _execute_script_via_text_editor(filepath, script_args=None, valid_ctx=None, 
         args_dict = script_args if script_args is not None else {}
         args_json = json.dumps(args_dict, default=str)
         prepend_code = f"import json\nimport bpy\nargs = json.loads({repr(args_json)})\ncontext = bpy.context\n"
-        
+
         # Combine prepended code with original script
         full_script = prepend_code + script_content
-        
+
         # Create a temporary text block
         temp_name = f"__chordsong_temp_{os.path.basename(filepath)}"
         # Remove existing temp block if it exists
         if temp_name in bpy.data.texts:
             bpy.data.texts.remove(bpy.data.texts[temp_name])
-        
+
         # Create new text block with the script content
         text_block = bpy.data.texts.new(temp_name)
         text_block.write(full_script)
-        
+
         # Prepare context override
         override = bpy.context.copy()
         override["edit_text"] = text_block
-        
+
         # Execute the script
         if valid_ctx:
             try:
@@ -377,12 +365,12 @@ def _execute_script_via_text_editor(filepath, script_args=None, valid_ctx=None, 
         else:
             with bpy.context.temp_override(**override):
                 bpy.ops.text.run_script()
-        
+
         # Clean up temporary text block
         bpy.data.texts.remove(text_block)
-        
+
         return True, None
-        
+
     except Exception as e:
         import traceback
         # Clean up text block if it exists
@@ -392,7 +380,7 @@ def _execute_script_via_text_editor(filepath, script_args=None, valid_ctx=None, 
                 bpy.data.texts.remove(bpy.data.texts[temp_name])
             except Exception:
                 pass
-        
+
         error_msg = f"Failed to execute script {filepath}: {e}"
         print(f"Chord Song: {error_msg}")
         traceback.print_exc()
@@ -411,7 +399,7 @@ def execute_history_entry_script(context, entry):
             error_msg = "Script execution is disabled. Enable 'Allow Custom User Scripts' in Preferences."
             print(f"Chord Song: {error_msg}")
             return False, error_msg
-        
+
         import os
         if not os.path.exists(entry.python_file):
             error_msg = f"Script file not found: {entry.python_file}"


### PR DESCRIPTION
Feature: Make overlay closable via chord (chordsong.close_overlay) + allow custom Recents chord

- Add chordsong.close_overlay operator (alias to reset_state)
- Remove hard-coded double-leader Recents behavior
- Add migration notice for existing users with no Recents chord
- Add smart close detection for any chordsong.close_overlay chord (only closes when the close-key wouldn't form a chord prefix)
- Add dynamic footer showing actual bound keys for close and recents
- Fix Recents modal cleanup to prevent input locking
- Disable key repeat for leader key

Closes #11